### PR TITLE
Integrate cspell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,13 +1,36 @@
 {
   "version": "0.1",
-  "language": "en",
+  "language": "en-US",
   "ignorePaths": [
     "**/node_modules/**",
     "**/vscode-extension/**",
     "**/.git/**",
     ".vscode",
     "package-lock.json",
-    "report"
+    "report",
+    "themes"
   ],
-  "words": []
+  "words": [
+    "bibtex",
+    "blogdown",
+    "bookdown",
+    "Colomb",
+    "DMPonline",
+    "Fidus",
+    "markdownlint",
+    "neuro",
+    "neuroimaging",
+    "neuroscience",
+    "neuroscientific",
+    "NFDI",
+    "pandoc",
+    "Prettier",
+    "RDMO",
+    "Rmarkdown",
+    "RRID",
+    "subfolder",
+    "subfolders",
+    "zenodo",
+    "zotero"
+  ]
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Lint Markdown files
         uses: DavidAnson/markdownlint-cli2-action@v2
       - name: Spell-check Markdown files
-        uses: streetsidesoftware/cspell-action@v1
+        uses: streetsidesoftware/cspell-action@v1.2.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: '**/*.{md,Rmd,Rmarkdown}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint Markdown files
         uses: DavidAnson/markdownlint-cli2-action@v2
+      - name: Spell-check Markdown files
+        uses: streetsidesoftware/cspell-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: '**/*.{md,Rmd,Rmarkdown}'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,9 @@
 {
   "recommendations": [
     "davidanson.vscode-markdownlint",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "editorconfig.editorconfig",
+    "redhat.vscode-yaml",
+    "streetsidesoftware.code-spell-checker"
   ]
 }

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,7 @@
 ---
 title: Home
+# cSpell:ignore tonictool
+# cSpell:ignore neuro
 ---
 
 # GIN-Tonic: a digital shelf for your research files
@@ -13,7 +15,7 @@ While the tools were developed in order to be integrated in the G-node Infrastru
 
 The Tonic project aims to develop a common file structure for (neuro-)scientific research projects,
 as well as software to facilitate its use.
-Our ultimate goal is to facilitate data, project and lab managment
+Our ultimate goal is to facilitate data, project and lab management
 using an open source approach and technologically relatively simple approach.
 
 [We are data managers](about) who support project templates and tooling for project structure creation, extension and validation.
@@ -22,12 +24,12 @@ This site documents the tools and gives guidelines on how to best use them.
 ## Overview
 
 This project stands on a [research folder structure standard](standard),
-which is a template of folders to give a similar organisation of files for different research projects.
+which is a template of folders to give a similar organization of files for different research projects.
 In contrast to the other tools, this first output can be used independently of a git-based technology.
 
 The other tools are extensions making the work with git servers (GIN, GitHub or GitLab) easier.
-Scripts synchronise content between machines and a Git server via a double click.
-The [Tonic](tooling/tonictool) application automates complex administrative tasks
+Scripts synchronize content between machines and a Git server via a double click.
+The [Tonic] application automates complex administrative tasks
 like the creation of project repositories and user management.
 
 ## Development status
@@ -48,3 +50,4 @@ Tonic has been initiated to augment the [GIN] (G-Node infrastructure), a version
 but isn't restricted to GIN.
 
 [gin]: https://gin.g-node.org
+[tonic]: /tooling/tonictool

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -7,7 +7,7 @@ weight: 9
 
 Three German research centers consortium (CRC, funded by the DFG)
 pulled their resources together with G-Node and the [NFDI-neuro initiative][nfdi]
-to tackle the issue of data organisation and came up with the Tonic project.
+to tackle the issue of data organization and came up with the Tonic project.
 
 ## You want to contribute ?
 

--- a/content/standard/01_project_management.md
+++ b/content/standard/01_project_management.md
@@ -13,13 +13,13 @@ Be sure not to include personal data if you are sharing (or planning to share) t
 ## Content
 
 This folder will contain mostly text documents related to the management of the project,
-like correspondence with university, funders and coworkers, minutes of meetings and ethical permits.
+like correspondence with university, funding agency and co-workers, minutes of meetings and ethical permits.
 In addition, we put data managements plans and paper notebook in this folder.
 
-## Organisation
+## Organization
 
 {{% expand "01_administration_files" %}}
-Any administrative material coming from the university of the funder shall come here.
+Any administrative material coming from the university of the funding agency shall come here.
 
 For example, one may save public contact information, quotes and bills, or official letters in this folder
 {{%/  expand%}}
@@ -43,7 +43,7 @@ but save the pdf in a common place for the whole lab to save data storage space.
 {{%/  expand%}}
 
 {{% expand "05 data management plans" %}}
-The data management plans will (under other tasks) explain how you will organise and name your dataset files,
+The data management plans will (under other tasks) explain how you will organize and name your dataset files,
 what standards you will use, and where the data will be published.
 It is important to make it available and easy to access,
 in order to facilitate the implementation of the plan during the research process.
@@ -53,7 +53,7 @@ There are different tools and templates available, like DMPonline or the RDMO to
 
 {{% expand "06_notebook" %}}
 Save digital notebook information here.
-It could be photos of a paper notebook, self-organised text files, data exported from an electronic lab notebook (ELN).
+It could be photos of a paper notebook, self-organized text files, data exported from an electronic lab notebook (ELN).
 If you are using an ELN, you may better have a link in the project main readme file.
 {{%/  expand%}}
 

--- a/content/standard/02_material_method.md
+++ b/content/standard/02_material_method.md
@@ -19,7 +19,7 @@ For instance, reagents shall be best documented at the time of purchase.
 
 One can use RRID numbers for reagents, and doi for protocols as unique identifiers.
 
-## Organisation
+## Organization
 
 One may use a key reagent table (a spreadsheet) to collect information about reagents.
 

--- a/content/standard/03_data.md
+++ b/content/standard/03_data.md
@@ -13,9 +13,9 @@ The use of submodule technology may help with that.
 This folder will contain datasets, that is information collected, gathered or created during the research project.
 One project usually has several experiments and each experiment shall get its own folder.
 
-## Organisation
+## Organization
 
-The organisation is quite loose for the time being,
+The organization is quite loose for the time being,
 but specific templates for your data types may exist (see BIDS format for neuroimaging data for example).
 
 - Each experiment/dataset gets one subfolder.

--- a/content/standard/04_data_analysis.md
+++ b/content/standard/04_data_analysis.md
@@ -4,18 +4,18 @@ weight: 5
 ---
 
 {{% notice info%}}
-In a GIN workflow, it may also be a submoduole,
-miror of a GitHub or GitLab repository.
+In a GIN workflow, it may also be a submodule,
+mirror of a GitHub or GitLab repository.
 {{% / notice %}}
 
 ## Content
 
 This folder will contain either code (in python, R or
-matlab), or textdescription of the analysis, or both.
+matlab), or textual description of the analysis, or both.
 
-## Organisation
+## Organization
 
-The content may be organised following the different
+The content may be organized following the different
 experiments, or by different figures created or a mix of
 these two. In addition we have 2 folder already present in
 the template:
@@ -23,7 +23,7 @@ the template:
 {{% expand "990\_code\_libraries" %}}
 Here comes the
 dependencies of your software, it might be the dependencies
-themselves, or a link/miror to the dependencies.
+themselves, or a link/mirror to the dependencies.
 
 You may want to use a container technology to deal with your
 code libraries.

--- a/content/standard/05_figures.md
+++ b/content/standard/05_figures.md
@@ -6,7 +6,7 @@ weight: 6
 {{% notice info%}}
 Here comes figures you created. It is advised to use the `990_shared_figures` folder to save figures ready for the manuscript,
 as this folder is meant to be shared as a submodule.
-It will allow links from manuscript to figures to still work when using a different folder organisation based of manuscript edition.
+It will allow links from manuscript to figures to still work when using a different folder organization based of manuscript edition.
 {{% / notice %}}
 
 ## Content
@@ -14,9 +14,9 @@ It will allow links from manuscript to figures to still work when using a differ
 This folder will contain all figures created during the research process. It is advised to use vector figures (adobe illustrator,
 or .pdf, .svg files) when possible, as their size does not change with higher quality outputs.
 
-## Organisation
+## Organization
 
-Similarly to the analysis folder, The content may be organised following the different
+Similarly to the analysis folder, The content may be organized following the different
 experiments, or by different figures created or a mix of
 these two. In addition we have one folder already present in
 the template:

--- a/content/standard/06_ dissemination.md
+++ b/content/standard/06_ dissemination.md
@@ -1,6 +1,7 @@
 ---
 title: 6 Dissemination
 weight: 7
+# cSpell:ignore textdoc
 ---
 
 {{% notice info%}}
@@ -8,7 +9,7 @@ This folder is usually not shared in its entirety, but specific subfolder are us
 
 One may want to keep all dissemination material in one place, independently of the project they belong to.
 To this end, you may want to use links,
-folder aliases or cloud technologies to reorganise the same content at different places.
+folder aliases or cloud technologies to reorganize the same content at different places.
 {{% / notice %}}
 
 ## Content
@@ -16,11 +17,11 @@ folder aliases or cloud technologies to reorganise the same content at different
 This folder contains files meant for scholarly communication and reports. It ranges from a presentation for a lab report,
 to a conference poster or a manuscript.
 
-## Organisation
+## Organization
 
 This folder is separated between different dissemination types, with reports and conference material on one side,
 and manuscript on the other side.
-This was done because manuscripts are a particluar research outputs that often requires a special sharing strategy.
+This was done because manuscripts are a particular research outputs that often requires a special sharing strategy.
 
 {{% notice warning%}}
 File naming convention and the version control system is particularly important in this folder.
@@ -45,7 +46,7 @@ or simply have files listed in the repository.
 
 {{% expand "02:manuscript" %}}
 Here will come the manuscripts for your project.
-This may be a link to a document written on a collaborative working platform (overleaf, googledoc, fiduswriter, pubpub, ....)
+This may be a link to a document written on a collaborative working platform (Overleaf, Google Docs, Fidus Writer, PubPub, …)
 or a document (markdown,latex, docx).
 
 You are advised to link or save the data coming from your reference manager

--- a/content/standard/_index.Rmarkdown
+++ b/content/standard/_index.Rmarkdown
@@ -10,7 +10,7 @@ weight: 1
 
 Read more about the Tonic folder structure and its background. This can be useful,
 
-- … if you're a user and need to do some manual project maintainance
+- … if you're a user and need to do some manual project maintenance
 - … if you're a tool developer who wants to contribute or implement a compliant tool
 
 Here is an overview of the standard and its 7 high level folders (project level).

--- a/content/standard/_index.markdown
+++ b/content/standard/_index.markdown
@@ -10,7 +10,7 @@ weight: 1
 
 Read more about the Tonic folder structure and its background. This can be useful,
 
-- … if you’re a user and need to do some manual project maintainance
+- … if you’re a user and need to do some manual project maintenance
 - … if you’re a tool developer who wants to contribute or implement a compliant tool
 
 Here is an overview of the standard and its 7 high level folders (project level).

--- a/content/standard/quickstart.md
+++ b/content/standard/quickstart.md
@@ -1,11 +1,12 @@
 ---
 title: Quick start
 weight: 1
+# cSpell:ignore textreports
 ---
 
 {{% notice info%}}
 This is the minimal information you should read before using the standard.
-It is organised via when you will use what folder and does not go into details.
+It is organized via when you will use what folder and does not go into details.
 {{% / notice %}}
 
 {{% notice warning%}}
@@ -25,10 +26,10 @@ If you want to **add new folders**, please tell us so we can include them in a f
 
 ### Data acquisition and analysis
 
-- Data is organised first following experiments, as subfolder of the **\*03_data** folder.
+- Data is organized first following experiments, as subfolder of the **\*03_data** folder.
   Make sure to describe every experiment in a readme file and link to the adequate files saved in 02_material_methods.
 
-- Refer to a data organisation guide or a data management plan to organise the files in that folder.
+- Refer to a data organization guide or a data management plan to organize the files in that folder.
   Any file coming directly from your hardware (raw data) or that is manually created (raw, derived data, or manually analysed data)
   should be in the experiment folder.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.0.1",
       "license": "CC-BY-SA-4.0",
       "devDependencies": {
+        "cspell": "^5.6.6",
         "husky": "^6.0.0",
         "lint-staged": "^11.0.0",
         "markdownlint-cli2": "^0.1.3",
@@ -102,6 +103,261 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@cspell/cspell-bundled-dicts": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-5.6.6.tgz",
+      "integrity": "sha512-am79SwDYrs0g1aLmtoZDWIj/IT070ISPoZabpTqnR58MFn0NGrLlF9yEKy3oVZtJhe10L3WWHreYZkdELLS9Sg==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/dict-ada": "^1.1.2",
+        "@cspell/dict-aws": "^1.0.14",
+        "@cspell/dict-bash": "^1.0.15",
+        "@cspell/dict-companies": "^1.0.38",
+        "@cspell/dict-cpp": "^1.1.39",
+        "@cspell/dict-cryptocurrencies": "^1.0.10",
+        "@cspell/dict-csharp": "^1.0.11",
+        "@cspell/dict-css": "^1.0.11",
+        "@cspell/dict-django": "^1.0.26",
+        "@cspell/dict-dotnet": "^1.0.27",
+        "@cspell/dict-elixir": "^1.0.24",
+        "@cspell/dict-en_us": "^1.2.44",
+        "@cspell/dict-en-gb": "^1.1.31",
+        "@cspell/dict-filetypes": "^1.1.7",
+        "@cspell/dict-fonts": "^1.0.14",
+        "@cspell/dict-fullstack": "^1.0.38",
+        "@cspell/dict-golang": "^1.1.24",
+        "@cspell/dict-haskell": "^1.0.13",
+        "@cspell/dict-html": "^1.1.7",
+        "@cspell/dict-html-symbol-entities": "^1.0.23",
+        "@cspell/dict-java": "^1.0.22",
+        "@cspell/dict-latex": "^1.0.25",
+        "@cspell/dict-lorem-ipsum": "^1.0.22",
+        "@cspell/dict-lua": "^1.0.16",
+        "@cspell/dict-node": "^1.0.12",
+        "@cspell/dict-npm": "^1.0.15",
+        "@cspell/dict-php": "^1.0.24",
+        "@cspell/dict-powershell": "^1.0.16",
+        "@cspell/dict-python": "^1.0.35",
+        "@cspell/dict-ruby": "^1.0.14",
+        "@cspell/dict-rust": "^1.0.22",
+        "@cspell/dict-scala": "^1.0.21",
+        "@cspell/dict-software-terms": "^1.0.37",
+        "@cspell/dict-typescript": "^1.0.19"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@cspell/cspell-types": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-5.6.5.tgz",
+      "integrity": "sha512-NCcMIelcQFwr2Yu9ma0buVBAFBlqtlxvAurV5UYmdaYyFv6bKO81HN9oMpu5DFev0ntOjZUSYdAGAhCUuikd3w==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-ada": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-1.1.2.tgz",
+      "integrity": "sha512-UDrcYcKIVyXDz5mInJabRNQpJoehjBFvja5W+GQyu9pGcx3BS3cAU8mWENstGR0Qc/iFTxB010qwF8F3cHA/aA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-aws": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-1.0.14.tgz",
+      "integrity": "sha512-K21CfB4ZpKYwwDQiPfic2zJA/uxkbsd4IQGejEvDAhE3z8wBs6g6BwwqdVO767M9NgZqc021yAVpr79N5pWe3w==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-bash": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-1.0.15.tgz",
+      "integrity": "sha512-rY5Bq4RWTgJTioG8vqFbCmnalc/UEM+iBuAZBYvBfT3nU/6SN00Zjyvlh823ir2ODkUryT29CwRYwXcPnuM04w==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-companies": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-1.0.38.tgz",
+      "integrity": "sha512-5GzatV4gOAvRW8Hz9T90XMN/svRhmzQecE4C7EcSibZkHZC1o3frTFNuzN2eKzvWb0f9xKuhOBcw9+jm8T9BzQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-cpp": {
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-1.1.39.tgz",
+      "integrity": "sha512-zrQjzMaT5YqAa4PMEaLfOWnfyh4uJjW53kwtuTo9nfJPaga2+FfrqdeWD8XYMxvTGCtzjivXhAn4FDIMh+66YQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-cryptocurrencies": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-1.0.10.tgz",
+      "integrity": "sha512-47ABvDJOkaST/rXipNMfNvneHUzASvmL6K/CbOFpYKfsd0x23Jc9k1yaOC7JAm82XSC/8a7+3Yu+Fk2jVJNnsA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-csharp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-1.0.11.tgz",
+      "integrity": "sha512-nub+ZCiTgmT87O+swI+FIAzNwaZPWUGckJU4GN402wBq420V+F4ZFqNV7dVALJrGaWH7LvADRtJxi6cZVHJKeA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-css": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-1.0.11.tgz",
+      "integrity": "sha512-2Or5oF5ojaXYD8QbO4Z+QdaNXSp+ZyNLJdeyKfejbxLvpL5feSNB0oYtTNrweFPTAvJKQ4DJsdEXy0/s31haRg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-django": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-1.0.26.tgz",
+      "integrity": "sha512-mn9bd7Et1L2zuibc08GVHTiD2Go3/hdjyX5KLukXDklBkq06r+tb0OtKtf1zKodtFDTIaYekGADhNhA6AnKLkg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-dotnet": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-1.0.27.tgz",
+      "integrity": "sha512-Ap/qpvZa6JTZI/I4ou3zJHKByjTMA6toaAUXDm4h9xVBiSESD1EkraZ/Z130w/NmJja7Xjv/UurH5IM6xGjTJQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-elixir": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-1.0.24.tgz",
+      "integrity": "sha512-pEX6GYlEx4Teusw/m+XmqoXzcHOqpcn1ZX4H33ONqR81XdPwbaKorBr1IG23Ic76IhwrFlOqs48tcnxrHYpFnA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-en_us": {
+      "version": "1.2.44",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-1.2.44.tgz",
+      "integrity": "sha512-pdq/HXsrB34VRYZIv7jidikIQBVLSKyCLkRXBvmkbUg4NkfpNcmmA1bVXc3gOhgghDNctGXe5UIIl8hfY1nvEg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-en-gb": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.31.tgz",
+      "integrity": "sha512-4VtiDhMOWrgimmYYHO0oQDSs6izvAnAhpLHoBzFeME6XMpO15XDzMWvd8ICca7kk5hk+XEGnPF4Mpa5aHJh6Pg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-filetypes": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-1.1.7.tgz",
+      "integrity": "sha512-b0e+eiBzTiL1yJZgPBGHP8G7Z0Kkpr/35dXlR9LWoP/EnrAlVj0ulXwErPgTwSoFdxWBgbDJjKZsrMdxWCckuA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-fonts": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-1.0.14.tgz",
+      "integrity": "sha512-VhIX+FVYAnqQrOuoFEtya6+H72J82cIicz9QddgknsTqZQ3dvgp6lmVnsQXPM3EnzA8n1peTGpLDwHzT7ociLA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-fullstack": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-1.0.38.tgz",
+      "integrity": "sha512-4reajWiUxwWrSyZaWm9e15kaWzjYcZbzlB+CVcxE1+0NqdIoqlEESDhbnrAjKPSq+jspKtes7nQ1CdZEOj1gCA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-golang": {
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-1.1.24.tgz",
+      "integrity": "sha512-qq3Cjnx2U1jpeWAGJL1GL0ylEhUMqyaR36Xij6Y6Aq4bViCRp+HRRqk0x5/IHHbOrti45h3yy7ii1itRFo+Xkg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-haskell": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-1.0.13.tgz",
+      "integrity": "sha512-kvl8T84cnYRPpND/P3D86P6WRSqebsbk0FnMfy27zo15L5MLAb3d3MOiT1kW3vEWfQgzUD7uddX/vUiuroQ8TA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-html": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-1.1.7.tgz",
+      "integrity": "sha512-5pea/5fA4iy1s5ko+JvCzNsCO5FGdjT006feVmCIxpUsPdgrV/7ONdm6508XOftot3opRlhEqWq/kB8H+GNdrQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-html-symbol-entities": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-1.0.23.tgz",
+      "integrity": "sha512-PV0UBgcBFbBLf/m1wfkVMM8w96kvfHoiCGLWO6BR3Q9v70IXoE4ae0+T+f0CkxcEkacMqEQk/I7vuE9MzrjaNw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-java": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-1.0.22.tgz",
+      "integrity": "sha512-CVAJ29dx1XwwutgsMgaj5eCl1Nc7X7qFhWL2KkAdu78A/NUIaS+1I9KS0hHhdZx/wLke9dH8TR7NyPQGpGxeAw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-latex": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-1.0.25.tgz",
+      "integrity": "sha512-cEgg91Migqcp1SdVV7dUeMxbPDhxdNo6Fgq2eygAXQjIOFK520FFvh/qxyBvW90qdZbIRoU2AJpchyHfGuwZFA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-lorem-ipsum": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-1.0.22.tgz",
+      "integrity": "sha512-yqzspR+2ADeAGUxLTfZ4pXvPl7FmkENMRcGDECmddkOiuEwBCWMZdMP5fng9B0Q6j91hQ8w9CLvJKBz10TqNYg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-lua": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-1.0.16.tgz",
+      "integrity": "sha512-YiHDt8kmHJ8nSBy0tHzaxiuitYp+oJ66ffCYuFWTNB3//Y0SI4OGHU3omLsQVeXIfCeVrO4DrVvRDoCls9B5zQ==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-node": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-1.0.12.tgz",
+      "integrity": "sha512-RPNn/7CSkflAWk0sbSoOkg0ORrgBARUjOW3QjB11KwV1gSu8f5W/ij/S50uIXtlrfoBLqd4OyE04jyON+g/Xfg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-npm": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-1.0.15.tgz",
+      "integrity": "sha512-6N1G1rGi5AsCaDu9mu+VmrrAj5S9gHv8TvJlarauDeEMS6uVl+ce2JpzDf7ld3Qu/4Dkr0sKS63OeA0DKeQTkw==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-php": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-1.0.24.tgz",
+      "integrity": "sha512-vHCqETX1idT9tN1plkxUFnXMIHjbbrNOINZh1PYSvVlBrOdahSaL/g6dOJZC5QTaaidoU4WXUlgnNb/7JN4Plg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-powershell": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-1.0.16.tgz",
+      "integrity": "sha512-cbauyYR6H53gfd/J9B3wgly9kg1joLSVxxqbry+y0BqF7FBtkctnXev2WHRbX68o6X9iQPhUz6+3zGKwFW5Stg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-python": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-1.0.35.tgz",
+      "integrity": "sha512-vVlx01SG8VjNHAQGaE/OGSShX1CoiXmdmCBsPX2sip6JmBluengGPtRPhpVLQOMxnXvTKg96eGtcnVRrYkVzag==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-ruby": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-1.0.14.tgz",
+      "integrity": "sha512-XHBGN4U1y9rjRuqrCA+3yIm2TCdhwwHXpOEcWkNeyXm8K03yPnIrKFS+kap8GTTrLpfNDuFsrmkkQTa7ssXLRA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-rust": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-1.0.22.tgz",
+      "integrity": "sha512-7WOIzv0BPiU+MssZbbMk8K+HR/g9Bcvd0+jXJC3/AKT8L6l0Mx0Tr/oF7cJ4xvCYgA84nBz3PhMZkabGSz/Nkg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-scala": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-1.0.21.tgz",
+      "integrity": "sha512-5V/R7PRbbminTpPS3ywgdAalI9BHzcEjEj9ug4kWYvBIGwSnS7T6QCFCiu+e9LvEGUqQC+NHgLY4zs1NaBj2vA==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-software-terms": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-1.0.37.tgz",
+      "integrity": "sha512-dK4vdeohyVw60h4w6j9V4pfgi6Vv4vaxS67X6By7IXPIH+S/mBcHiXhqnGXqWFSfPNB7Oh+GP47nPLAHHFRZRg==",
+      "dev": true
+    },
+    "node_modules/@cspell/dict-typescript": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-1.0.19.tgz",
+      "integrity": "sha512-qmJApzoVskDeJnLZzZMaafEDGbEg5Elt4c3Mpg49SWzIHm1N4VXCp5CcFfHsOinJ30dGrs3ARAJGJZIw56kK6A==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -293,6 +549,12 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -415,6 +677,43 @@
         "node": ">=6"
       }
     },
+    "node_modules/clear-module": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.1.tgz",
+      "integrity": "sha512-ng0E7LeODcT3QkazOckzZqbca+JByQy/Q2Z6qO24YsTp+pLxCfohGz2gJYJqZS0CWTX3LEUiHOqe5KlYeUbEMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clear-module/node_modules/parent-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clear-module/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -496,10 +795,49 @@
         "node": ">= 10"
       }
     },
+    "node_modules/comment-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.0.tgz",
+      "integrity": "sha512-WEghmVYaNq9NlWbrkzQTSsya9ycLyxJxpTQfZEan6a5Jomnjw18zS3Podf8q1Zf9BvonvQd/+Z7Z39L7KKzzdQ==",
+      "dev": true,
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.2",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "node_modules/cosmiconfig": {
@@ -530,6 +868,117 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cspell": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-5.6.6.tgz",
+      "integrity": "sha512-4k3Jcz61mv5SQNjVcrWjARcEVa7gOF8nyg5MPU68AWPoyg5VuE51jgQDr4c01dbG/PGRLtrLwVmr+r6Kh5RDVA==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/cspell-types": "^5.6.5",
+        "chalk": "^4.1.1",
+        "commander": "^7.2.0",
+        "comment-json": "^4.1.0",
+        "cspell-glob": "^5.6.5",
+        "cspell-lib": "^5.6.6",
+        "fs-extra": "^10.0.0",
+        "get-stdin": "^8.0.0",
+        "glob": "^7.1.7",
+        "strip-ansi": "^6.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "bin": {
+        "cspell": "bin.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
+      }
+    },
+    "node_modules/cspell-glob": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-5.6.5.tgz",
+      "integrity": "sha512-bobER7IoYBJZCXxkiAc5FT1Tb55TFLf1vZSw0ORCFYMeMHlvYktwDx0Wo6/Nkz39MtMQ9nvLrepCMEEZNpKhVw==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cspell-io": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.6.5.tgz",
+      "integrity": "sha512-OcnuiOkOetcWtihBF57fefLTNPHgsNEc7+x04U7hto3lwEWe8CFQfnkLbQIZfzXOyiyuPY2yjDO0/Y3oqWrB3A==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "iterable-to-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cspell-lib": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-5.6.6.tgz",
+      "integrity": "sha512-Sum4U7/xWTJm99DeZF0bFBBN5SQ7roArlwnnKMmuRRcYl3s9/3OgtIK2YOOgqoSCxh4G51f7aal+bNAlAnx1bA==",
+      "dev": true,
+      "dependencies": {
+        "@cspell/cspell-bundled-dicts": "^5.6.6",
+        "@cspell/cspell-types": "^5.6.5",
+        "clear-module": "^4.1.1",
+        "comment-json": "^4.1.0",
+        "configstore": "^5.0.1",
+        "cosmiconfig": "^7.0.0",
+        "cspell-glob": "^5.6.5",
+        "cspell-io": "^5.6.5",
+        "cspell-trie-lib": "^5.6.5",
+        "find-up": "^5.0.0",
+        "fs-extra": "^10.0.0",
+        "gensequence": "^3.1.1",
+        "import-fresh": "^3.3.0",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cspell-lib/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.6.5.tgz",
+      "integrity": "sha512-x4Ii8LwFp7tt+Ie+5R/a/qgYn43R5RwRfByn3taMy4D++PgF+vHTVZm1yORmUFBPTIT39gFbtkAJR7X0kdBL/w==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "^10.0.0",
+        "gensequence": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/debug": {
@@ -603,6 +1052,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-prop/node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -664,6 +1134,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/execa": {
@@ -739,6 +1222,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -758,11 +1257,34 @@
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
+    "node_modules/fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/gensequence": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.1.1.tgz",
+      "integrity": "sha512-ys3h0hiteRwmY6BsvSttPmkhC0vEQHPJduANBRtH/dlDPZ0UBIb/dXy80IcckXyuQ6LKg+PloRqvGER9IS7F7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -778,6 +1300,18 @@
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
       "dev": true
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
@@ -821,6 +1355,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/globby": {
@@ -868,10 +1414,25 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -917,6 +1478,18 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -942,6 +1515,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -965,6 +1547,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "node_modules/is-arrayish": {
@@ -1039,6 +1627,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1062,6 +1656,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/iterable-to-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/iterable-to-stream/-/iterable-to-stream-2.0.0.tgz",
+      "integrity": "sha512-efkLePxXjJk92hvN+2rS3tGJTRn8/tqXjmZvPI6LQ29xCj2sUF4zW8hkMsVe3jpTkxtMZ89xsKnz9FaRqNWM6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -1098,6 +1701,18 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.0.3",
@@ -1173,6 +1788,21 @@
         "enquirer": ">= 2.3.0 < 3"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -1245,6 +1875,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-it": {
@@ -1448,6 +2093,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -1491,6 +2166,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -1604,6 +2288,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1626,6 +2319,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/responselike": {
@@ -1708,6 +2413,21 @@
       },
       "engines": {
         "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/semver-compare": {
@@ -1884,11 +2604,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -1919,6 +2669,12 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+      "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1957,6 +2713,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -2001,6 +2778,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -2082,6 +2871,258 @@
           }
         }
       }
+    },
+    "@cspell/cspell-bundled-dicts": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-5.6.6.tgz",
+      "integrity": "sha512-am79SwDYrs0g1aLmtoZDWIj/IT070ISPoZabpTqnR58MFn0NGrLlF9yEKy3oVZtJhe10L3WWHreYZkdELLS9Sg==",
+      "dev": true,
+      "requires": {
+        "@cspell/dict-ada": "^1.1.2",
+        "@cspell/dict-aws": "^1.0.14",
+        "@cspell/dict-bash": "^1.0.15",
+        "@cspell/dict-companies": "^1.0.38",
+        "@cspell/dict-cpp": "^1.1.39",
+        "@cspell/dict-cryptocurrencies": "^1.0.10",
+        "@cspell/dict-csharp": "^1.0.11",
+        "@cspell/dict-css": "^1.0.11",
+        "@cspell/dict-django": "^1.0.26",
+        "@cspell/dict-dotnet": "^1.0.27",
+        "@cspell/dict-elixir": "^1.0.24",
+        "@cspell/dict-en_us": "^1.2.44",
+        "@cspell/dict-en-gb": "^1.1.31",
+        "@cspell/dict-filetypes": "^1.1.7",
+        "@cspell/dict-fonts": "^1.0.14",
+        "@cspell/dict-fullstack": "^1.0.38",
+        "@cspell/dict-golang": "^1.1.24",
+        "@cspell/dict-haskell": "^1.0.13",
+        "@cspell/dict-html": "^1.1.7",
+        "@cspell/dict-html-symbol-entities": "^1.0.23",
+        "@cspell/dict-java": "^1.0.22",
+        "@cspell/dict-latex": "^1.0.25",
+        "@cspell/dict-lorem-ipsum": "^1.0.22",
+        "@cspell/dict-lua": "^1.0.16",
+        "@cspell/dict-node": "^1.0.12",
+        "@cspell/dict-npm": "^1.0.15",
+        "@cspell/dict-php": "^1.0.24",
+        "@cspell/dict-powershell": "^1.0.16",
+        "@cspell/dict-python": "^1.0.35",
+        "@cspell/dict-ruby": "^1.0.14",
+        "@cspell/dict-rust": "^1.0.22",
+        "@cspell/dict-scala": "^1.0.21",
+        "@cspell/dict-software-terms": "^1.0.37",
+        "@cspell/dict-typescript": "^1.0.19"
+      }
+    },
+    "@cspell/cspell-types": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-5.6.5.tgz",
+      "integrity": "sha512-NCcMIelcQFwr2Yu9ma0buVBAFBlqtlxvAurV5UYmdaYyFv6bKO81HN9oMpu5DFev0ntOjZUSYdAGAhCUuikd3w==",
+      "dev": true
+    },
+    "@cspell/dict-ada": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-1.1.2.tgz",
+      "integrity": "sha512-UDrcYcKIVyXDz5mInJabRNQpJoehjBFvja5W+GQyu9pGcx3BS3cAU8mWENstGR0Qc/iFTxB010qwF8F3cHA/aA==",
+      "dev": true
+    },
+    "@cspell/dict-aws": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-1.0.14.tgz",
+      "integrity": "sha512-K21CfB4ZpKYwwDQiPfic2zJA/uxkbsd4IQGejEvDAhE3z8wBs6g6BwwqdVO767M9NgZqc021yAVpr79N5pWe3w==",
+      "dev": true
+    },
+    "@cspell/dict-bash": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-1.0.15.tgz",
+      "integrity": "sha512-rY5Bq4RWTgJTioG8vqFbCmnalc/UEM+iBuAZBYvBfT3nU/6SN00Zjyvlh823ir2ODkUryT29CwRYwXcPnuM04w==",
+      "dev": true
+    },
+    "@cspell/dict-companies": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-1.0.38.tgz",
+      "integrity": "sha512-5GzatV4gOAvRW8Hz9T90XMN/svRhmzQecE4C7EcSibZkHZC1o3frTFNuzN2eKzvWb0f9xKuhOBcw9+jm8T9BzQ==",
+      "dev": true
+    },
+    "@cspell/dict-cpp": {
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-1.1.39.tgz",
+      "integrity": "sha512-zrQjzMaT5YqAa4PMEaLfOWnfyh4uJjW53kwtuTo9nfJPaga2+FfrqdeWD8XYMxvTGCtzjivXhAn4FDIMh+66YQ==",
+      "dev": true
+    },
+    "@cspell/dict-cryptocurrencies": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-1.0.10.tgz",
+      "integrity": "sha512-47ABvDJOkaST/rXipNMfNvneHUzASvmL6K/CbOFpYKfsd0x23Jc9k1yaOC7JAm82XSC/8a7+3Yu+Fk2jVJNnsA==",
+      "dev": true
+    },
+    "@cspell/dict-csharp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-1.0.11.tgz",
+      "integrity": "sha512-nub+ZCiTgmT87O+swI+FIAzNwaZPWUGckJU4GN402wBq420V+F4ZFqNV7dVALJrGaWH7LvADRtJxi6cZVHJKeA==",
+      "dev": true
+    },
+    "@cspell/dict-css": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-1.0.11.tgz",
+      "integrity": "sha512-2Or5oF5ojaXYD8QbO4Z+QdaNXSp+ZyNLJdeyKfejbxLvpL5feSNB0oYtTNrweFPTAvJKQ4DJsdEXy0/s31haRg==",
+      "dev": true
+    },
+    "@cspell/dict-django": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-1.0.26.tgz",
+      "integrity": "sha512-mn9bd7Et1L2zuibc08GVHTiD2Go3/hdjyX5KLukXDklBkq06r+tb0OtKtf1zKodtFDTIaYekGADhNhA6AnKLkg==",
+      "dev": true
+    },
+    "@cspell/dict-dotnet": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-1.0.27.tgz",
+      "integrity": "sha512-Ap/qpvZa6JTZI/I4ou3zJHKByjTMA6toaAUXDm4h9xVBiSESD1EkraZ/Z130w/NmJja7Xjv/UurH5IM6xGjTJQ==",
+      "dev": true
+    },
+    "@cspell/dict-elixir": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-1.0.24.tgz",
+      "integrity": "sha512-pEX6GYlEx4Teusw/m+XmqoXzcHOqpcn1ZX4H33ONqR81XdPwbaKorBr1IG23Ic76IhwrFlOqs48tcnxrHYpFnA==",
+      "dev": true
+    },
+    "@cspell/dict-en_us": {
+      "version": "1.2.44",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-1.2.44.tgz",
+      "integrity": "sha512-pdq/HXsrB34VRYZIv7jidikIQBVLSKyCLkRXBvmkbUg4NkfpNcmmA1bVXc3gOhgghDNctGXe5UIIl8hfY1nvEg==",
+      "dev": true
+    },
+    "@cspell/dict-en-gb": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.31.tgz",
+      "integrity": "sha512-4VtiDhMOWrgimmYYHO0oQDSs6izvAnAhpLHoBzFeME6XMpO15XDzMWvd8ICca7kk5hk+XEGnPF4Mpa5aHJh6Pg==",
+      "dev": true
+    },
+    "@cspell/dict-filetypes": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-1.1.7.tgz",
+      "integrity": "sha512-b0e+eiBzTiL1yJZgPBGHP8G7Z0Kkpr/35dXlR9LWoP/EnrAlVj0ulXwErPgTwSoFdxWBgbDJjKZsrMdxWCckuA==",
+      "dev": true
+    },
+    "@cspell/dict-fonts": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-1.0.14.tgz",
+      "integrity": "sha512-VhIX+FVYAnqQrOuoFEtya6+H72J82cIicz9QddgknsTqZQ3dvgp6lmVnsQXPM3EnzA8n1peTGpLDwHzT7ociLA==",
+      "dev": true
+    },
+    "@cspell/dict-fullstack": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-1.0.38.tgz",
+      "integrity": "sha512-4reajWiUxwWrSyZaWm9e15kaWzjYcZbzlB+CVcxE1+0NqdIoqlEESDhbnrAjKPSq+jspKtes7nQ1CdZEOj1gCA==",
+      "dev": true
+    },
+    "@cspell/dict-golang": {
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-1.1.24.tgz",
+      "integrity": "sha512-qq3Cjnx2U1jpeWAGJL1GL0ylEhUMqyaR36Xij6Y6Aq4bViCRp+HRRqk0x5/IHHbOrti45h3yy7ii1itRFo+Xkg==",
+      "dev": true
+    },
+    "@cspell/dict-haskell": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-1.0.13.tgz",
+      "integrity": "sha512-kvl8T84cnYRPpND/P3D86P6WRSqebsbk0FnMfy27zo15L5MLAb3d3MOiT1kW3vEWfQgzUD7uddX/vUiuroQ8TA==",
+      "dev": true
+    },
+    "@cspell/dict-html": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-1.1.7.tgz",
+      "integrity": "sha512-5pea/5fA4iy1s5ko+JvCzNsCO5FGdjT006feVmCIxpUsPdgrV/7ONdm6508XOftot3opRlhEqWq/kB8H+GNdrQ==",
+      "dev": true
+    },
+    "@cspell/dict-html-symbol-entities": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-1.0.23.tgz",
+      "integrity": "sha512-PV0UBgcBFbBLf/m1wfkVMM8w96kvfHoiCGLWO6BR3Q9v70IXoE4ae0+T+f0CkxcEkacMqEQk/I7vuE9MzrjaNw==",
+      "dev": true
+    },
+    "@cspell/dict-java": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-1.0.22.tgz",
+      "integrity": "sha512-CVAJ29dx1XwwutgsMgaj5eCl1Nc7X7qFhWL2KkAdu78A/NUIaS+1I9KS0hHhdZx/wLke9dH8TR7NyPQGpGxeAw==",
+      "dev": true
+    },
+    "@cspell/dict-latex": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-1.0.25.tgz",
+      "integrity": "sha512-cEgg91Migqcp1SdVV7dUeMxbPDhxdNo6Fgq2eygAXQjIOFK520FFvh/qxyBvW90qdZbIRoU2AJpchyHfGuwZFA==",
+      "dev": true
+    },
+    "@cspell/dict-lorem-ipsum": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-1.0.22.tgz",
+      "integrity": "sha512-yqzspR+2ADeAGUxLTfZ4pXvPl7FmkENMRcGDECmddkOiuEwBCWMZdMP5fng9B0Q6j91hQ8w9CLvJKBz10TqNYg==",
+      "dev": true
+    },
+    "@cspell/dict-lua": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-1.0.16.tgz",
+      "integrity": "sha512-YiHDt8kmHJ8nSBy0tHzaxiuitYp+oJ66ffCYuFWTNB3//Y0SI4OGHU3omLsQVeXIfCeVrO4DrVvRDoCls9B5zQ==",
+      "dev": true
+    },
+    "@cspell/dict-node": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-1.0.12.tgz",
+      "integrity": "sha512-RPNn/7CSkflAWk0sbSoOkg0ORrgBARUjOW3QjB11KwV1gSu8f5W/ij/S50uIXtlrfoBLqd4OyE04jyON+g/Xfg==",
+      "dev": true
+    },
+    "@cspell/dict-npm": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-1.0.15.tgz",
+      "integrity": "sha512-6N1G1rGi5AsCaDu9mu+VmrrAj5S9gHv8TvJlarauDeEMS6uVl+ce2JpzDf7ld3Qu/4Dkr0sKS63OeA0DKeQTkw==",
+      "dev": true
+    },
+    "@cspell/dict-php": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-1.0.24.tgz",
+      "integrity": "sha512-vHCqETX1idT9tN1plkxUFnXMIHjbbrNOINZh1PYSvVlBrOdahSaL/g6dOJZC5QTaaidoU4WXUlgnNb/7JN4Plg==",
+      "dev": true
+    },
+    "@cspell/dict-powershell": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-1.0.16.tgz",
+      "integrity": "sha512-cbauyYR6H53gfd/J9B3wgly9kg1joLSVxxqbry+y0BqF7FBtkctnXev2WHRbX68o6X9iQPhUz6+3zGKwFW5Stg==",
+      "dev": true
+    },
+    "@cspell/dict-python": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-1.0.35.tgz",
+      "integrity": "sha512-vVlx01SG8VjNHAQGaE/OGSShX1CoiXmdmCBsPX2sip6JmBluengGPtRPhpVLQOMxnXvTKg96eGtcnVRrYkVzag==",
+      "dev": true
+    },
+    "@cspell/dict-ruby": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-1.0.14.tgz",
+      "integrity": "sha512-XHBGN4U1y9rjRuqrCA+3yIm2TCdhwwHXpOEcWkNeyXm8K03yPnIrKFS+kap8GTTrLpfNDuFsrmkkQTa7ssXLRA==",
+      "dev": true
+    },
+    "@cspell/dict-rust": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-1.0.22.tgz",
+      "integrity": "sha512-7WOIzv0BPiU+MssZbbMk8K+HR/g9Bcvd0+jXJC3/AKT8L6l0Mx0Tr/oF7cJ4xvCYgA84nBz3PhMZkabGSz/Nkg==",
+      "dev": true
+    },
+    "@cspell/dict-scala": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-1.0.21.tgz",
+      "integrity": "sha512-5V/R7PRbbminTpPS3ywgdAalI9BHzcEjEj9ug4kWYvBIGwSnS7T6QCFCiu+e9LvEGUqQC+NHgLY4zs1NaBj2vA==",
+      "dev": true
+    },
+    "@cspell/dict-software-terms": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-1.0.37.tgz",
+      "integrity": "sha512-dK4vdeohyVw60h4w6j9V4pfgi6Vv4vaxS67X6By7IXPIH+S/mBcHiXhqnGXqWFSfPNB7Oh+GP47nPLAHHFRZRg==",
+      "dev": true
+    },
+    "@cspell/dict-typescript": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-1.0.19.tgz",
+      "integrity": "sha512-qmJApzoVskDeJnLZzZMaafEDGbEg5Elt4c3Mpg49SWzIHm1N4VXCp5CcFfHsOinJ30dGrs3ARAJGJZIw56kK6A==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2230,6 +3271,12 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2321,6 +3368,33 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
+    "clear-module": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.1.tgz",
+      "integrity": "sha512-ng0E7LeODcT3QkazOckzZqbca+JByQy/Q2Z6qO24YsTp+pLxCfohGz2gJYJqZS0CWTX3LEUiHOqe5KlYeUbEMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "parent-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+          "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.1.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -2387,10 +3461,43 @@
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true
     },
+    "comment-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.0.tgz",
+      "integrity": "sha512-WEghmVYaNq9NlWbrkzQTSsya9ycLyxJxpTQfZEan6a5Jomnjw18zS3Podf8q1Zf9BvonvQd/+Z7Z39L7KKzzdQ==",
+      "dev": true,
+      "requires": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.2",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cosmiconfig": {
@@ -2415,6 +3522,92 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true
+    },
+    "cspell": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-5.6.6.tgz",
+      "integrity": "sha512-4k3Jcz61mv5SQNjVcrWjARcEVa7gOF8nyg5MPU68AWPoyg5VuE51jgQDr4c01dbG/PGRLtrLwVmr+r6Kh5RDVA==",
+      "dev": true,
+      "requires": {
+        "@cspell/cspell-types": "^5.6.5",
+        "chalk": "^4.1.1",
+        "commander": "^7.2.0",
+        "comment-json": "^4.1.0",
+        "cspell-glob": "^5.6.5",
+        "cspell-lib": "^5.6.6",
+        "fs-extra": "^10.0.0",
+        "get-stdin": "^8.0.0",
+        "glob": "^7.1.7",
+        "strip-ansi": "^6.0.0",
+        "vscode-uri": "^3.0.2"
+      }
+    },
+    "cspell-glob": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-5.6.5.tgz",
+      "integrity": "sha512-bobER7IoYBJZCXxkiAc5FT1Tb55TFLf1vZSw0ORCFYMeMHlvYktwDx0Wo6/Nkz39MtMQ9nvLrepCMEEZNpKhVw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^4.0.4"
+      }
+    },
+    "cspell-io": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.6.5.tgz",
+      "integrity": "sha512-OcnuiOkOetcWtihBF57fefLTNPHgsNEc7+x04U7hto3lwEWe8CFQfnkLbQIZfzXOyiyuPY2yjDO0/Y3oqWrB3A==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "^0.6.3",
+        "iterable-to-stream": "^2.0.0"
+      }
+    },
+    "cspell-lib": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-5.6.6.tgz",
+      "integrity": "sha512-Sum4U7/xWTJm99DeZF0bFBBN5SQ7roArlwnnKMmuRRcYl3s9/3OgtIK2YOOgqoSCxh4G51f7aal+bNAlAnx1bA==",
+      "dev": true,
+      "requires": {
+        "@cspell/cspell-bundled-dicts": "^5.6.6",
+        "@cspell/cspell-types": "^5.6.5",
+        "clear-module": "^4.1.1",
+        "comment-json": "^4.1.0",
+        "configstore": "^5.0.1",
+        "cosmiconfig": "^7.0.0",
+        "cspell-glob": "^5.6.5",
+        "cspell-io": "^5.6.5",
+        "cspell-trie-lib": "^5.6.5",
+        "find-up": "^5.0.0",
+        "fs-extra": "^10.0.0",
+        "gensequence": "^3.1.1",
+        "import-fresh": "^3.3.0",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "cspell-trie-lib": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.6.5.tgz",
+      "integrity": "sha512-x4Ii8LwFp7tt+Ie+5R/a/qgYn43R5RwRfByn3taMy4D++PgF+vHTVZm1yORmUFBPTIT39gFbtkAJR7X0kdBL/w==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^10.0.0",
+        "gensequence": "^3.1.1"
       }
     },
     "debug": {
@@ -2462,6 +3655,23 @@
       "dev": true,
       "requires": {
         "path-type": "^4.0.0"
+      }
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
+      },
+      "dependencies": {
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
+        }
       }
     },
     "emoji-regex": {
@@ -2513,6 +3723,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "execa": {
@@ -2576,6 +3792,16 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -2592,10 +3818,27 @@
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "gensequence": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.1.1.tgz",
+      "integrity": "sha512-ys3h0hiteRwmY6BsvSttPmkhC0vEQHPJduANBRtH/dlDPZ0UBIb/dXy80IcckXyuQ6LKg+PloRqvGER9IS7F7g==",
       "dev": true
     },
     "get-caller-file": {
@@ -2608,6 +3851,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true
     },
     "get-stream": {
@@ -2637,6 +3886,15 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
       }
     },
     "globby": {
@@ -2672,10 +3930,22 @@
         "responselike": "^2.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true
     },
     "http-cache-semantics": {
@@ -2706,6 +3976,15 @@
       "integrity": "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -2721,6 +4000,12 @@
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -2742,6 +4027,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "is-arrayish": {
@@ -2795,6 +4086,12 @@
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -2811,6 +4108,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "iterable-to-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/iterable-to-stream/-/iterable-to-stream-2.0.0.tgz",
+      "integrity": "sha512-efkLePxXjJk92hvN+2rS3tGJTRn8/tqXjmZvPI6LQ29xCj2sUF4zW8hkMsVe3jpTkxtMZ89xsKnz9FaRqNWM6g==",
       "dev": true
     },
     "js-tokens": {
@@ -2845,6 +4148,16 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
     },
     "keyv": {
       "version": "4.0.3",
@@ -2908,6 +4221,15 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
     "log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -2959,6 +4281,15 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      }
     },
     "markdown-it": {
       "version": "12.0.4",
@@ -3110,6 +4441,24 @@
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
     "p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -3139,6 +4488,12 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -3207,6 +4562,12 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3224,6 +4585,15 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.1"
+      }
     },
     "responselike": {
       "version": "2.0.0",
@@ -3276,6 +4646,18 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -3406,10 +4788,34 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "uri-js": {
@@ -3436,6 +4842,12 @@
         "yargs": "^16.1.0"
       }
     },
+    "vscode-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+      "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==",
+      "dev": true
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3460,6 +4872,24 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
     "y18n": {
@@ -3493,6 +4923,12 @@
       "version": "20.2.7",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
       "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier -w . **/*.{Rmd,Rmarkdown}",
-    "spell": "cspell **/*.{md,Rmd,Rmarkdown}",
+    "spell": "cspell '**/*.{md,Rmd,Rmarkdown}'",
     "prelint": "npm run format",
     "lint": "markdownlint-cli2-fix",
     "postlint": "npm run spell",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier -w . **/*.{Rmd,Rmarkdown}",
+    "spell": "cspell **/*.{md,Rmd,Rmarkdown}",
     "prelint": "npm run format",
     "lint": "markdownlint-cli2-fix",
+    "postlint": "npm run spell",
     "watch": "hugo server --watch --navigateToChanged",
     "prepare": "husky install"
   },
@@ -23,6 +25,7 @@
   "homepage": "https://gin-tonic.netlify.app",
   "private": true,
   "devDependencies": {
+    "cspell": "^5.6.6",
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",
     "markdownlint-cli2": "^0.1.3",


### PR DESCRIPTION
This PR adds [cspell] to the project, a spell-checker for code. It detects actual typos like “thnaks” or mixed usage of US and british orthography, but it doesn't check grammar or capitalization. False-positives can be added to the `.cspell.json` file, I have already added about 20 domain-specific words like neuroscience. Words and ignores can also added per file in comments. I'm not sure how annoying this would be in practical usage.

- It integrates with VS Code and checks during writing
- It runs as a gh action on PR and checks files that have changed
- It is added to the NPM package definition as devDependency and spell script

[cspell]: https://github.com/streetsidesoftware/cspell